### PR TITLE
identical drivers for original and temporary images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ $manipulators[] = new Infinityweb\Glide\Optimizer\OptimizerManipulator();
 
 $server->getApi()->setManipulators($manipulators);
 ```
+
+
+For better optimization use Imageick driver.

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ $server->getApi()->setManipulators($manipulators);
 ```
 
 
-For better optimization use Imageick driver.
+For better optimization use imagick driver.

--- a/src/OptimizerManipulator.php
+++ b/src/OptimizerManipulator.php
@@ -2,14 +2,25 @@
 
 namespace Infinityweb\Glide\Optimizer;
 
-use Intervention\Image\Image;
 use ImageOptimizer\OptimizerFactory;
+use Intervention\Image\Image;
 use League\Glide\Manipulators\BaseManipulator;
 use Psr\Log\LoggerInterface;
 
-class OptimizerManipulator extends BaseManipulator {
-
+/**'
+ * Class OptimizerManipulator
+ * @package Infinityweb\Glide\Optimizer
+ */
+class OptimizerManipulator extends BaseManipulator
+{
+    /**
+     * @var OptimizerFactory|null
+     */
     protected $optimizerFactory = null;
+
+    /**
+     * @var array
+     */
     protected $config = [
         /*
           |--------------------------------------------------------------------------
@@ -20,49 +31,53 @@ class OptimizerManipulator extends BaseManipulator {
           | which optipng
           |
          */
-        'options'           => [
-        ],
+        'options' => [],
         /*
           |--------------------------------------------------------------------------
           | Transformer for image
           |--------------------------------------------------------------------------
           |
-          | You can choice which tranformer you will use
+          | You can choice which transformer you will use
           |
          */
         'transform_handler' => [
             'image/x-png' => 'pngquant',
-            'image/png'   => 'pngquant',
+            'image/png' => 'pngquant',
             'image/pjpeg' => 'jpegoptim',
-            'image/jpeg'  => 'jpegoptim',
-            'image/gif'   => 'gifsicle',
+            'image/jpeg' => 'jpegoptim',
+            'image/gif' => 'gifsicle',
         ],
     ];
 
     /**
      * Create Optimizer instance.
-     * @param array $config 
+     *
+     * @param array $config
+     * @param LoggerInterface|null $logger
      */
-    public function __construct(array $config = [], LoggerInterface $logger = null) {
-
-        $this->config['options'] = array_merge($this->config['options'],$config);
-
+    public function __construct(array $config = [], LoggerInterface $logger = null)
+    {
+        $this->config['options'] = array_merge($this->config['options'], $config);
 
         $this->optimizerFactory = new OptimizerFactory($this->config['options'], $logger);
     }
 
     /**
      * Perform optimize image.
+     *
      * @param  Image $image The source image.
      * @return Image The manipulated image.
+     * @return Image
+     * @throws \Exception
      */
-    public function run(Image $image) {
-
+    public function run(Image $image)
+    {
         $tmp = tempnam(sys_get_temp_dir(), 'GlideOptimizer');
 
         file_put_contents($tmp, $image->getEncoded());
 
         $imageTmp = \Intervention\Image\ImageManagerStatic::make($tmp);
+        $imageTmp->setDriver($image->getDriver());
 
         if (!isset($this->config['transform_handler'][$imageTmp->mime()])) {
             throw new \Exception('TransformHandler for file mime: "' . $image->mime() . '" was not found');
@@ -76,5 +91,4 @@ class OptimizerManipulator extends BaseManipulator {
 
         return $image;
     }
-
 }


### PR DESCRIPTION
I've research that Imagick driver make better image optimization.
Resized image without optimization: 63.4 KB
Resized image with optiomization by GD driver (default): 70.1 KB
Resized image with optimization by Imagick driver: 53.6 KB