### PR TITLE
Update version constraint for league/glide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "league/glide": "^1.5",
+        "league/glide": "^1.5 || ^2.0",
         "psr/log": "^1.1",
         "ps/image-optimizer": "^2.0"
     },


### PR DESCRIPTION
Glide has a new v2 release using Flystem v2. Glide's public API remains pretty much the same so no other change is needed to support v2.